### PR TITLE
Travis: Adding Travis CI configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha ./test/*.*"
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha ./test/*.*",
+    "coveralls": "npm run coverage -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,9 @@
   "homepage": "https://github.com/mercadopago/px-nodejs#readme",
   "devDependencies": {
     "chai": "^3.5.0",
+    "coveralls": "^2.11.15",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "mocha-lcov-reporter": "^1.2.0"
   }
 }

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "6"
+  - "5"
+  - "4"
+  - "0"
+after_success:
+- npm run coveralls


### PR DESCRIPTION
## Cambios generales
* Se agrego travis.yml con la configuración
* Se genero la tarea de coveralls para reporte de cobertura

## Issues cerrados
 * Closes #10 

- El repositorio debería estar público para poder habilitar Travis CI
- Una vez público, primero habilitar el Coveralls para que la ejecución de Travis CI no falle. Luego habilitar Travis CI