### PR TITLE
Suscription: Add shorcut methods to cancel and pause preapproval

### DIFF
--- a/lib/resources/preapproval.js
+++ b/lib/resources/preapproval.js
@@ -24,3 +24,37 @@ preapproval.search = requestManager.describe({
   path: '/preapproval/search',
   method: 'GET'
 });
+
+/**
+ * Cancel a prepparoval
+ * @param id
+ * @param callback
+ * @returns {*}
+ */
+preapproval.cancel = function (id, callback) {
+  var preapprovalId = (typeof arguments[0] === 'object') ? arguments[0].id : arguments[0];
+
+  if (typeof callback !== 'function' || callback === undefined) callback = function () {};
+
+  return this.update({
+    id: preapprovalId,
+    status: 'cancelled'
+  }, callback);
+};
+
+/**
+ * Pause a preapproval
+ * @param id
+ * @param callback
+ * @returns {*}
+ */
+preapproval.pause = function (id, callback) {
+  var preapprovalId = (typeof arguments[0] === 'object') ? arguments[0].id : arguments[0];
+
+  if (typeof callback !== 'function' || callback === undefined) callback = function () {};
+
+  return this.update({
+    id: preapprovalId,
+    status: 'paused'
+  }, callback);
+};

--- a/test/preapproval.js
+++ b/test/preapproval.js
@@ -1,0 +1,127 @@
+/* eslint-env node, mocha */
+var chai = require('chai');
+var sinon = require('sinon');
+var chaiAsPromised = require('chai-as-promised');
+var Promise = require('bluebird');
+var assert = chai.assert;
+var preapprovalModule = require('../lib/resources/preapproval');
+
+chai.use(chaiAsPromised);
+
+describe('Preapproval Resource', function () {
+  it('Cancel', function () {
+    var promise;
+    var promiseCallback;
+    var promiseObjectArg;
+    var callback = sinon.spy();
+
+    var stub = sinon.stub(preapprovalModule, 'update', function (id, putCallback) {
+      return new Promise(function (resolve) {
+        resolve({});
+        return putCallback.apply(null, [null, {}]);
+      });
+    });
+
+    promise = preapprovalModule.cancel(1);
+
+    assert.isFulfilled(promise);
+
+    promise.then(function(response){
+      var stubArgs = stub.args[0][0];
+
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+      assert.equal(stubArgs.id, 1);
+      assert.equal(stubArgs.status, 'cancelled');
+    });
+
+    promiseCallback = preapprovalModule.cancel(1, callback);
+
+    assert.isFulfilled(promiseCallback);
+
+    promiseCallback.then(function(response){
+      var callbackResponse = callback.args[0][1];
+
+      assert.equal(JSON.stringify(callbackResponse), JSON.stringify({}));
+
+      assert.isTrue(callback.called);
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+    });
+
+    promiseObjectArg = preapprovalModule.cancel({
+      id: 1
+    });
+
+    assert.isFulfilled(promiseObjectArg);
+
+    promise.then(function(response){
+      var stubArgs = stub.args[0][0];
+
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+      assert.equal(stubArgs.id, 1);
+      assert.equal(stubArgs.status, 'cancelled');
+    });
+
+    stub.restore();
+  });
+
+  it('Refund', function () {
+    var promise;
+    var promiseCallback;
+    var promiseObjectArg;
+    var callback = sinon.spy();
+
+    var stub = sinon.stub(preapprovalModule, 'update', function (id, putCallback) {
+      return new Promise(function (resolve) {
+        resolve({});
+        return putCallback.apply(null, [null, {}]);
+      });
+    });
+
+    promise = preapprovalModule.pause(1);
+
+    assert.isFulfilled(promise);
+
+    promise.then(function(response){
+      var stubArgs = stub.args[0][0];
+
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+      assert.equal(stubArgs.id, 1);
+      assert.equal(stubArgs.status, 'paused');
+    });
+
+    promiseCallback = preapprovalModule.pause(1, callback);
+
+    assert.isFulfilled(promiseCallback);
+
+    promiseCallback.then(function(response){
+      var callbackResponse = callback.args[0][1];
+
+      assert.equal(JSON.stringify(callbackResponse), JSON.stringify({}));
+
+      assert.isTrue(callback.called);
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+    });
+
+    promiseObjectArg = preapprovalModule.pause({
+      id: 1
+    });
+
+    assert.isFulfilled(promiseObjectArg);
+
+    promise.then(function(response){
+      var stubArgs = stub.args[0][0];
+
+      assert.isTrue(stub.called);
+      assert.equal(JSON.stringify(response), JSON.stringify({}));
+      assert.equal(stubArgs.id, 1);
+      assert.equal(stubArgs.status, 'paused');
+    });
+
+    stub.restore();
+  });
+});


### PR DESCRIPTION
## Cambios realizados para el feature:
 * Agregar shorcut para cancelar un preapproval
 * Agregar shorcut para pausar un preapproval
 
## Issues cerrados
 * Closes #36 
 
## Checklist validación PR:
- [X] Título y descripción clara del PR
- [X] Tests de mi funcionalidad 
- [X] Tests ejecutados y pasados
- [X] Branch Coverage >= 80%